### PR TITLE
fix issue with no tty

### DIFF
--- a/pre_commit_hooks/circleci-validate.sh
+++ b/pre_commit_hooks/circleci-validate.sh
@@ -7,6 +7,8 @@ set -o nounset
 DEBUG=${DEBUG:=0}
 [[ $DEBUG -eq 1 ]] && set -o xtrace
 
+exec < /dev/tty
+
 echo 'Begin circleci config validation'
 
 if ! command -v circleci &>/dev/null; then


### PR DESCRIPTION
When running this hook locally I was getting an error about the input device not being a TTY:

```
$ pre-commit run --all
CircleCI config validation...............................................Failed
hookid: circleci-validate

Begin circleci config validation
the input device is not a TTY
```

A simple modification to the shell script gets it working again for me. I found the solution on the CircleCI blog:  https://circleci.com/blog/circleci-hacks-validate-circleci-config-on-every-commit-with-a-git-hook/



