### PR TITLE
Fork https://github.com/danielhoherd/pre-commit-circleci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,5 @@
----
+# Don't use this config for your own repositories. See "Installation" in README.md.
 repos:
-  - repo: git@github.com:danielhoherd/pre-commit-circleci.git
-    rev: v0.0.3
-    hooks:
-      - id: circleci-validate
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.15.0
     hooks:

--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,8 @@ The MIT License (MIT)
 
 Copyright (c) 2016 detailyang
 
+Copyright (c) 2020 KoBold Metals
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/README.md
+++ b/README.md
@@ -1,65 +1,54 @@
 [![GitHub License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/circleci/local-cli/master/LICENSE)
 
-# DEPRECATION NOTICE and call for further development
-
-This repo is no longer being maintained since I no longer use Circle-CI.
-
-[The upstream project that pre-commit hook relies on](https://github.com/circleci/local-cli) has also been deprecated and replaced with <https://github.com/CircleCI-Public/circleci-cli>.
-
-If you use Circle-CI and find this project useful, please consider forking this project and making it work with the new circleci-cli. If you do so, open a ticket here and I will link to your project.
-
 # pre-commit-circleci
 
-pre-commit-circleci is a [pre-commit](https://github.com/pre-commit/pre-commit) component, which wraps [circleci](https://github.com/circleci/local-cli) to check CircleCI config yaml files.
-
-Table of Contents
------------------
-
-  * [Requirements](#requirements)
-  * [Install](#install)
-  * [Contributing](#contributing)
-  * [License](#license)
-  * [Author](#author)
-
-Requirements
-------------
-  pre-commit-circleci requires the following to run:
-
-  * [pre-commit](http://pre-commit.com)
-  * [circleci local-cli](https://github.com/circleci/local-cli)
-  * [docker](https://www.docker.com/) is a prerequisite for circleci local-cli
+`pre-commit-circleci` is a
+[pre-commit](https://github.com/pre-commit/pre-commit) component that checks
+CircleCI configuration YAML files in Git repositories.  It wraps
+[circleci-cli](https://github.com/CircleCI-Public/circleci-cli) in a hook that
+pre-commit can use.
 
 
-Install
----------
+## Requirements
 
-1. create .pre-commit-config.yaml in you git project
-2. pre-commit install
-3. enjoy it
+`pre-commit-circleci` requires the following to run:
 
-example .pre-commit-config.yaml as following:
-
-```yaml
--   repo: http://github.com/danielhoherd/pre-commit-circleci
-    rev: v0.0.1
-    hooks:
-    - id: circleci-validate
-```
-
-Contributing
-------------
-
-To contribute to pre-commit-circleci, clone this repo locally and commit your code on a separate branch.
+* [pre-commit](http://pre-commit.com)
+* [circleci-cli](https://github.com/CircleCI-Public/circleci-cli)
 
 
-Author
-------
+## Installation
 
-- GitHub [@danielhoherd](https://github.com/danielhoherd)
-- GitHub [@detailyang](https://github.com/detailyang) - [pre-commit shell-lint](https://github.com/detailyang/pre-commit-shell) was used as a template for pre-commit circleci-validate.
+1. [Install pre-commit](https://pre-commit.com/#install).
+1. [Install circlei-cli](https://github.com/CircleCI-Public/circleci-cli).
+1. Create a `.pre-commit-config.yaml` file in your repository.  Set up CircleCI
+   validation as follows:
+   ```yaml
+   repos:
+     - repo: http://github.com/KoBoldMetals/pre-commit-circleci
+       rev: v0.0.4
+       hooks:
+       - id: circleci-validate
+   ```
+1. Run `pre-commit install` to install the hook.
 
 
-License
--------
+## Contributing
 
-pre-commit-circleci is licensed under the [MIT](https://github.com/danielhoherd/pre-commit-circleci/blob/master/LICENSE) license.  
+To contribute to `pre-commit-circleci`, clone this repository locally and
+commit your code on a separate branch, then submit a pull request.
+
+
+## Authors
+
+- GitHub [@mplough](https://github.com/mplough)
+- GitHub [@danielhoherd](https://github.com/danielhoherd) - forked from his
+  original [pre-commit-circle-ci](https://github.com/danielhoherd/pre-commit-circleci) tool.
+- GitHub [@detailyang](https://github.com/detailyang) - [pre-commit
+  shell-lint](https://github.com/detailyang/pre-commit-shell) was used as a
+  template for the validation hook.
+
+
+## License
+
+pre-commit-circleci is licensed under the [MIT](https://github.com/KoBoldMetals/pre-commit-circleci/blob/master/LICENSE) license.

--- a/pre_commit_hooks/circleci-validate.sh
+++ b/pre_commit_hooks/circleci-validate.sh
@@ -1,20 +1,14 @@
 #!/usr/bin/env bash
 
-echo "This pre-commit hook is DEPRECATED. Please see https://github.com/danielhoherd/pre-commit-circleci for more info."
-
-set -o errexit
-set -o pipefail
-set -o nounset
-
-DEBUG=${DEBUG:=0}
-[[ $DEBUG -eq 1 ]] && set -o xtrace
+set -eu -o pipefail
 
 exec < /dev/tty
 
-echo 'Begin circleci config validation'
+echo 'Validating CircleCI configuration ...'
 
 if ! command -v circleci &>/dev/null; then
-  >&2 echo 'circleci command not found. See https://circleci.com/docs/2.0/local-cli/ for installation instructions.'
+  >&2 echo 'circleci command not found. See https://github.com/CircleCI-Public/circleci-cli for installation instructions.'
+  >&2 echo 'See https://github.com/CircleCI-Public/circleci-cli for installation instructions.'
   exit 1
 fi
 

--- a/test/example-good-1.yml
+++ b/test/example-good-1.yml
@@ -21,11 +21,6 @@ jobs:
 
     working_directory: ~/my-project
 
-    branches:
-      ignore:
-        - develop
-        - /feature-.*/
-
     steps:
       - checkout
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -x
+
 command -v circleci &> /dev/null || {
   echo "are you sure you have installed circleci?"
   exit 1
@@ -10,15 +12,17 @@ tempdir="${HOME}/temp/circleci-validate-$(date +%s)"
 mkdir -p "${tempdir}" || exit 1
 cp -r . "${tempdir}"
 cd "${tempdir}" || exit 1
-git add .
-git commit -m "Test commit"
 
 cat << EOS > .pre-commit-config.yaml
--   repo: $(pwd)
-    sha: $(git rev-parse HEAD)
+repos:
+  - repo: $(pwd)
+    rev: $(git rev-parse HEAD)
     hooks:
-    -   id: circleci-validate
+      - id: circleci-validate
 EOS
+
+git add .
+git commit -m "Test commit"
 
 [ -d .circleci ] && rm -rf .circleci
 mkdir -p .circleci


### PR DESCRIPTION
This PR forks https://github.com/danielhoherd/pre-commit-circleci and updates the pre-commit hook to use the latest CircleCI CLI.  No need to maintain this here -- we are using CircleCI and can maintain over in the fork.  See https://github.com/KoBoldMetals/pre-commit-circleci.